### PR TITLE
Add comprehensive OSINT checks and grouped selection UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,37 +53,7 @@
                 <label class="block text-sm font-medium text-gray-700">Verificaciones a realizar</label>
                 <button id="selectAll" type="button" class="text-blue-600 text-sm">Seleccionar todos</button>
             </div>
-            <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="dnssec" class="h-4 w-4 rounded" checked><span class="ml-2 text-sm">DNSSEC</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="ipv4" class="h-4 w-4 rounded" checked><span class="ml-2 text-sm">IPv4</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="ipv6" class="h-4 w-4 rounded" checked><span class="ml-2 text-sm">IPv6</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="asn" class="h-4 w-4 rounded" checked><span class="ml-2 text-sm">ASN</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="rpki" class="h-4 w-4 rounded"><span class="ml-2 text-sm">RPKI</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="whois" class="h-4 w-4 rounded"><span class="ml-2 text-sm">WHOIS</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="dmarc" class="h-4 w-4 rounded" checked><span class="ml-2 text-sm">DMARC</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="spf" class="h-4 w-4 rounded" checked><span class="ml-2 text-sm">SPF</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="dkim" class="h-4 w-4 rounded"><span class="ml-2 text-sm">DKIM</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="mx" class="h-4 w-4 rounded"><span class="ml-2 text-sm">MX</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="smtputf8" class="h-4 w-4 rounded"><span class="ml-2 text-sm">SMTPUTF8</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="w3c" class="h-4 w-4 rounded"><span class="ml-2 text-sm">W3C</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="https" class="h-4 w-4 rounded"><span class="ml-2 text-sm">HTTPS</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="redirect" class="h-4 w-4 rounded"><span class="ml-2 text-sm">Redir. HTTPS</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="hsts" class="h-4 w-4 rounded"><span class="ml-2 text-sm">HSTS</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="csp" class="h-4 w-4 rounded"><span class="ml-2 text-sm">CSP</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="xfo" class="h-4 w-4 rounded"><span class="ml-2 text-sm">X-Frame-Options</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="xcto" class="h-4 w-4 rounded"><span class="ml-2 text-sm">X-Content-Type</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="referrer" class="h-4 w-4 rounded"><span class="ml-2 text-sm">Referrer-Policy</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="permissions" class="h-4 w-4 rounded"><span class="ml-2 text-sm">Permissions-Policy</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="xxss" class="h-4 w-4 rounded"><span class="ml-2 text-sm">X-XSS-Protection</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="server" class="h-4 w-4 rounded"><span class="ml-2 text-sm">Encabezado Server</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="compression" class="h-4 w-4 rounded"><span class="ml-2 text-sm">Compresión HTTP</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="ocsp" class="h-4 w-4 rounded"><span class="ml-2 text-sm">OCSP Stapling</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="tls" class="h-4 w-4 rounded"><span class="ml-2 text-sm">Versión TLS</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="key" class="h-4 w-4 rounded"><span class="ml-2 text-sm">Intercambio de Clave</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="caa" class="h-4 w-4 rounded"><span class="ml-2 text-sm">CAA</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="tlsa" class="h-4 w-4 rounded"><span class="ml-2 text-sm">TLSA</span></label>
-                <label class="check-label flex items-center p-2 border rounded-lg cursor-pointer"><input type="checkbox" data-check="securitytxt" class="h-4 w-4 rounded"><span class="ml-2 text-sm">security.txt</span></label>
-                </div>
+            <div id="checksContainer" class="space-y-3"></div>
         </div>
 
         <div class="flex flex-col items-center justify-center">
@@ -113,7 +83,7 @@
     const countrySelect = document.getElementById('countrySelect');
     const resultsContainer = document.getElementById('results');
     const loader = document.getElementById('loader');
-    const checkboxes = document.querySelectorAll('input[type="checkbox"][data-check]');
+    let checkboxes = [];
     const selectAllBtn = document.getElementById('selectAll');
     const historyButton = document.getElementById('historyButton');
     const clearHistoryButton = document.getElementById('clearHistoryButton');
@@ -199,37 +169,143 @@
         map.setView([0, 0], 2);
     }
 
-    const checkConfig = {
-        dnssec: { label: 'DNSSEC' },
-        ipv4: { label: 'IPv4' },
-        ipv6: { label: 'IPv6' },
-        asn: { label: 'ASN' },
-        rpki: { label: 'RPKI' },
-        whois: { label: 'WHOIS' },
-        dmarc: { label: 'DMARC' },
-        spf: { label: 'SPF' },
-        dkim: { label: 'DKIM' },
-        mx: { label: 'MX' },
-        smtputf8: { label: 'SMTPUTF8' },
-        w3c: { label: 'W3C' },
-        https: { label: 'HTTPS' },
-        redirect: { label: 'Redir. HTTPS' },
-        hsts: { label: 'HSTS' },
-        csp: { label: 'CSP' },
-        xfo: { label: 'X-Frame-Options' },
-        xcto: { label: 'X-Content-Type' },
-        referrer: { label: 'Referrer-Policy' },
-        permissions: { label: 'Permissions-Policy' },
-        xxss: { label: 'X-XSS-Protection' },
-        server: { label: 'Encabezado Server' },
-        compression: { label: 'Compresión HTTP' },
-        ocsp: { label: 'OCSP Stapling' },
-        tls: { label: 'Versión TLS' },
-        key: { label: 'Intercambio de Clave' },
-        caa: { label: 'CAA' },
-        tlsa: { label: 'TLSA' },
-        securitytxt: { label: 'security.txt' }
-    };
+    const groupDefinitions = [
+        {
+            title: 'IP y Red',
+            checks: [
+                { key: 'ipinfo', label: 'More IP Info', default: true },
+                { key: 'serverlocation', label: 'Server Location', default: true },
+                { key: 'serverinfo', label: 'Server Info', default: true },
+                { key: 'ipv4', label: 'IPv4', default: true },
+                { key: 'ipv6', label: 'IPv6', default: false },
+                { key: 'asn', label: 'ASN', default: true },
+                { key: 'serverstatus', label: 'Server Status', default: true },
+                { key: 'openports', label: 'Open Ports', default: false },
+                { key: 'traceroute', label: 'Traceroute', default: false },
+                { key: 'redirectchain', label: 'Redirect Chain', default: true },
+                { key: 'associatedhosts', label: 'Associated Hosts', default: false },
+                { key: 'block', label: 'Block Detection', default: false }
+            ]
+        },
+        {
+            title: 'DNS y Seguridad',
+            checks: [
+                { key: 'dnsrecords', label: 'DNS Records', default: true },
+                { key: 'txtrecords', label: 'TXT Records', default: true },
+                { key: 'dnsserver', label: 'DNS Server', default: true },
+                { key: 'dnssecurity', label: 'DNS Security Extensions', default: true },
+                { key: 'rpki', label: 'RPKI', default: false },
+                { key: 'caa', label: 'CAA', default: false },
+                { key: 'tlsa', label: 'TLSA', default: false }
+            ]
+        },
+        {
+            title: 'Correo y Mensajería',
+            checks: [
+                { key: 'emailconfig', label: 'Email Configuration', default: true },
+                { key: 'mx', label: 'MX', default: false },
+                { key: 'smtputf8', label: 'SMTPUTF8', default: false },
+                { key: 'dmarc', label: 'DMARC', default: true },
+                { key: 'spf', label: 'SPF', default: true },
+                { key: 'dkim', label: 'DKIM', default: false }
+            ]
+        },
+        {
+            title: 'Identidad y Cumplimiento',
+            checks: [
+                { key: 'whois', label: 'Whois Lookup', default: true },
+                { key: 'domaininfo', label: 'Domain Info', default: true },
+                { key: 'securitytxt', label: 'Security.txt', default: false }
+            ]
+        },
+        {
+            title: 'Contenido y Experiencia',
+            checks: [
+                { key: 'sitefeatures', label: 'Site Features', default: false },
+                { key: 'cookies', label: 'Cookies', default: false },
+                { key: 'crawlrules', label: 'Crawl Rules', default: false },
+                { key: 'linkedpages', label: 'Linked Pages', default: false },
+                { key: 'listedpages', label: 'Listed Pages', default: false },
+                { key: 'socialtags', label: 'Social Tags', default: false },
+                { key: 'quality', label: 'Quality Metrics', default: false },
+                { key: 'w3c', label: 'W3C Validator', default: false },
+                { key: 'carbon', label: 'Carbon Footprint', default: false },
+                { key: 'archive', label: 'Archive History', default: false },
+                { key: 'ranking', label: 'Global Ranking', default: false },
+                { key: 'malware', label: 'Malware & Phishing Detection', default: false },
+                { key: 'screenshot', label: 'Screenshot', default: false }
+            ]
+        },
+        {
+            title: 'Seguridad Web y TLS',
+            checks: [
+                { key: 'https', label: 'HTTPS', default: true },
+                { key: 'redirect', label: 'HTTPS Redirect', default: true },
+                { key: 'hsts', label: 'HTTP Strict Transport Security', default: true },
+                { key: 'csp', label: 'Content Security Policy', default: false },
+                { key: 'xfo', label: 'X-Frame-Options', default: false },
+                { key: 'xcto', label: 'X-Content-Type-Options', default: false },
+                { key: 'referrer', label: 'Referrer-Policy', default: false },
+                { key: 'permissions', label: 'Permissions-Policy', default: false },
+                { key: 'xxss', label: 'X-XSS-Protection', default: false },
+                { key: 'headers', label: 'Headers', default: false },
+                { key: 'server', label: 'Server Header', default: false },
+                { key: 'compression', label: 'HTTP Compression', default: false },
+                { key: 'ocsp', label: 'OCSP Stapling', default: false },
+                { key: 'tls', label: 'TLS Version', default: true },
+                { key: 'key', label: 'Key Exchange', default: false },
+                { key: 'sslchain', label: 'SSL Chain Info', default: false },
+                { key: 'tlsciphers', label: 'TLS Cipher Suites', default: false },
+                { key: 'tlsconfig', label: 'TLS Security Config', default: false },
+                { key: 'tlssimulation', label: 'TLS Handshake Simulation', default: false },
+                { key: 'httpsecurity', label: 'HTTP Security Features', default: false },
+                { key: 'firewall', label: 'Firewall Detection', default: false }
+            ]
+        }
+    ];
+
+    const checkConfig = {};
+    groupDefinitions.forEach(group => {
+        group.checks.forEach(check => {
+            checkConfig[check.key] = { label: check.label };
+        });
+    });
+
+    function renderCheckOptions() {
+        const container = document.getElementById('checksContainer');
+        container.innerHTML = '';
+        groupDefinitions.forEach(group => {
+            const details = document.createElement('details');
+            details.className = 'border rounded-lg bg-white shadow-sm';
+            details.open = true;
+            const summary = document.createElement('summary');
+            summary.className = 'cursor-pointer select-none px-3 py-2 font-semibold text-gray-700 flex items-center justify-between';
+            summary.innerHTML = `<span>${group.title}</span><span class="text-xs text-gray-500">${group.checks.length} checks</span>`;
+            details.appendChild(summary);
+            const wrapper = document.createElement('div');
+            wrapper.className = 'grid grid-cols-1 sm:grid-cols-2 gap-2 px-3 pb-3';
+            group.checks.forEach(check => {
+                const label = document.createElement('label');
+                label.className = 'check-label flex items-center p-2 border rounded-lg cursor-pointer bg-gray-50';
+                const input = document.createElement('input');
+                input.type = 'checkbox';
+                input.dataset.check = check.key;
+                if (check.default) input.checked = true;
+                input.className = 'h-4 w-4 rounded';
+                const span = document.createElement('span');
+                span.className = 'ml-2 text-sm';
+                span.textContent = check.label;
+                label.appendChild(input);
+                label.appendChild(span);
+                wrapper.appendChild(label);
+            });
+            details.appendChild(wrapper);
+            container.appendChild(details);
+        });
+        checkboxes = container.querySelectorAll('input[type="checkbox"][data-check]');
+    }
+
+    renderCheckOptions();
 
     function loadHistory() {
         const history = JSON.parse(localStorage.getItem('domainHistory') || '[]');
@@ -297,23 +373,57 @@
         return data;
     }
 
+    function escapeHtml(text) {
+        return String(text)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+    }
+
+    function formatDetails(details) {
+        if (details === undefined || details === null) return '';
+        if (Array.isArray(details)) {
+            return details
+                .map(item => {
+                    if (item && typeof item === 'object' && item.html) {
+                        return `<div class="text-xs text-gray-700">${item.html}</div>`;
+                    }
+                    return `<div class="text-xs text-gray-700">${escapeHtml(item)}</div>`;
+                })
+                .join('');
+        }
+        if (details && typeof details === 'object') {
+            if (details.html) return details.html;
+            return `<pre class="text-xs text-gray-700 whitespace-pre-wrap">${escapeHtml(JSON.stringify(details, null, 2))}</pre>`;
+        }
+        return `<span class="text-sm">${escapeHtml(details)}</span>`;
+    }
+
     function getStatusHtml(status, details = '') {
-        let icon, color, text;
+        let icon, color;
         switch (status) {
             case 'ok':
                 icon = `<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>`;
-                color = 'text-green-600'; text = details; break;
+                color = 'text-green-600';
+                break;
             case 'fail':
                 icon = `<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>`;
-                color = 'text-red-600'; text = details; break;
+                color = 'text-red-600';
+                break;
             case 'error':
                 icon = `<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>`;
-                color = 'text-gray-500'; text = details; break;
+                color = 'text-gray-500';
+                break;
+            case 'info':
+                icon = `<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>`;
+                color = 'text-blue-600';
+                break;
             default:
                 icon = `<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>`;
-                color = 'text-yellow-600'; text = details; break;
+                color = 'text-yellow-600';
+                break;
         }
-        return `<div class="flex items-center ${color}"><span class="mr-2 flex-shrink-0">${icon}</span><span class="font-semibold text-sm">${text}</span></div>`;
+        return `<div class="flex items-start ${color}"><span class="mr-2 flex-shrink-0">${icon}</span><div class="space-y-1">${formatDetails(details)}</div></div>`;
     }
 
     function createResultCard(domain, selectedChecks) {
@@ -324,21 +434,15 @@
         title.textContent = domain;
         card.appendChild(title);
 
-        const groups = {
-            "Configuración DNS y Red": ['dnssec', 'ipv4', 'ipv6', 'asn', 'rpki'],
-            "Registros de Correo y EAI": ['dmarc', 'spf', 'dkim', 'smtputf8', 'mx'],
-            "Información del Dominio": ['whois'],
-            "Web y Seguridad": ['w3c','https','redirect','hsts','csp','xfo','xcto','referrer','permissions','xxss','server','compression','ocsp','tls','key','caa','tlsa','securitytxt']
-        };
-
         const placeholders = {};
 
-        for (const [groupTitle, checkKeys] of Object.entries(groups)) {
-            const filtered = selectedChecks.filter(c => checkKeys.includes(c));
+        for (const group of groupDefinitions) {
+            const groupKeys = group.checks.map(c => c.key);
+            const filtered = selectedChecks.filter(c => groupKeys.includes(c));
             if (!filtered.length) continue;
             const h4 = document.createElement('h4');
             h4.className = 'text-md font-semibold text-gray-700 mt-4 mb-2';
-            h4.textContent = groupTitle;
+            h4.textContent = group.title;
             card.appendChild(h4);
             filtered.forEach(c => {
                 const row = document.createElement('div');
@@ -365,6 +469,270 @@
         const ascii = toASCII(domain);
         try {
             switch (checkType) {
+                case 'ipinfo': {
+                    const data = await fetchWithTimeout(`${API_BASE}/ipinfo/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const lines = [];
+                    if (data.ipv4?.length) lines.push(`IPv4: ${data.ipv4.join(', ')}`);
+                    if (data.ipv6?.length) lines.push(`IPv6: ${data.ipv6.join(', ')}`);
+                    if (data.geo?.length) {
+                        data.geo.forEach(g => {
+                            lines.push(`${g.ip}: ${[g.city, g.region, g.country].filter(Boolean).join(', ')}${g.asn ? ' (AS' + g.asn + ')' : ''}`);
+                        });
+                    }
+                    return { label, status: lines.length ? 'ok' : 'fail', details: lines.length ? lines : 'Sin datos' };
+                }
+                case 'serverlocation': {
+                    const data = await fetchWithTimeout(`${API_BASE}/serverlocation/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const parts = [data.city, data.region, data.country].filter(Boolean).join(', ');
+                    const details = parts ? `${parts} (${data.ip})` : data.ip;
+                    return { label, status: data.ip ? 'ok' : 'fail', details: details || 'Sin datos' };
+                }
+                case 'serverinfo': {
+                    const data = await fetchWithTimeout(`${API_BASE}/serverinfo/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const lines = [];
+                    if (data.asn) lines.push(`ASN: ${data.asn}`);
+                    if (data.org) lines.push(`Org: ${data.org}`);
+                    if (data.network) lines.push(`Red: ${data.network}`);
+                    if (data.city || data.country) lines.push(`Ubicación: ${[data.city, data.country].filter(Boolean).join(', ')}`);
+                    return { label, status: lines.length ? 'ok' : 'fail', details: lines.length ? lines : 'Sin datos' };
+                }
+                case 'serverstatus': {
+                    const data = await fetchWithTimeout(`${API_BASE}/serverstatus/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    return { label, status: data.statusCode && data.statusCode < 500 ? 'ok' : 'fail', details: `HTTP ${data.statusCode || 'sin respuesta'}` };
+                }
+                case 'openports': {
+                    const data = await fetchWithTimeout(`${API_BASE}/openports/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const open = data.ports?.filter(p => p.open).map(p => p.port) || [];
+                    return {
+                        label,
+                        status: open.length ? 'ok' : 'fail',
+                        details: open.length ? `Abiertos: ${open.join(', ')}` : 'Sin puertos comunes abiertos'
+                    };
+                }
+                case 'traceroute': {
+                    const data = await fetchWithTimeout(`${API_BASE}/traceroute/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const hops = data.hops?.slice(0, 10) || [];
+                    return { label, status: hops.length ? 'ok' : 'fail', details: hops.length ? hops : 'Sin datos' };
+                }
+                case 'redirectchain': {
+                    const data = await fetchWithTimeout(`${API_BASE}/redirectchain/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const chain = data.chain?.map(item => `${item.statusCode || '-'} → ${item.url}`) || [];
+                    return { label, status: chain.length ? 'ok' : 'fail', details: chain.length ? chain : 'Sin redirecciones' };
+                }
+                case 'associatedhosts': {
+                    const data = await fetchWithTimeout(`${API_BASE}/associatedhosts/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const hosts = data.hosts?.map(h => `${h.host} (${h.ip})`) || [];
+                    return { label, status: hosts.length ? 'ok' : 'fail', details: hosts.length ? hosts : 'Sin hosts asociados' };
+                }
+                case 'block': {
+                    const data = await fetchWithTimeout(`${API_BASE}/block/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const lines = data.results?.map(r => `${r.resolver}: ${r.blocked ? 'bloqueado' : 'acceso'}`) || [];
+                    const blocked = data.results?.some(r => r.blocked);
+                    return { label, status: blocked ? 'fail' : 'ok', details: lines.length ? lines : 'Sin datos' };
+                }
+                case 'dnsrecords': {
+                    const data = await fetchWithTimeout(`${API_BASE}/dnsrecords/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const records = [];
+                    Object.entries(data.records || {}).forEach(([type, values]) => {
+                        if (Array.isArray(values) && values.length) {
+                            const formatted = values
+                                .map(v => (typeof v === 'string' ? v : JSON.stringify(v)))
+                                .join(', ');
+                            records.push(`${type}: ${formatted}`);
+                        }
+                    });
+                    return { label, status: records.length ? 'ok' : 'fail', details: records.length ? records : 'Sin registros' };
+                }
+                case 'txtrecords': {
+                    const data = await fetchWithTimeout(`${API_BASE}/txtrecords/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const records = data.records?.map(r => r.join('')) || [];
+                    return { label, status: records.length ? 'ok' : 'fail', details: records.length ? records : 'Sin TXT' };
+                }
+                case 'dnsserver': {
+                    const data = await fetchWithTimeout(`${API_BASE}/dnsserver/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    return { label, status: data.servers?.length ? 'ok' : 'fail', details: data.servers?.length ? data.servers : 'Sin NS' };
+                }
+                case 'dnssecurity': {
+                    const data = await fetchWithTimeout(`${API_BASE}/dnssecurity/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const lines = [];
+                    if (data.algorithms?.length) lines.push(`Algoritmos: ${data.algorithms.join(', ')}`);
+                    if (data.doh) lines.push('DoH activo');
+                    lines.push(data.valid ? 'DNSSEC válido' : 'DNSSEC ausente');
+                    return { label, status: data.valid ? 'ok' : 'fail', details: lines };
+                }
+                case 'emailconfig': {
+                    const data = await fetchWithTimeout(`${API_BASE}/emailconfig/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const lines = [
+                        `SPF: ${data.spf ? 'sí' : 'no'}`,
+                        `DMARC: ${data.dmarc ? 'sí' : 'no'}`,
+                        `DKIM: ${data.dkim ? 'sí' : 'no'}`
+                    ];
+                    if (data.mx?.length) lines.push(`MX: ${data.mx.map(m => `${m.exchange} (p${m.priority})`).join(', ')}`);
+                    return { label, status: data.spf || data.dmarc || data.dkim ? 'ok' : 'fail', details: lines };
+                }
+                case 'sitefeatures': {
+                    const data = await fetchWithTimeout(`${API_BASE}/sitefeatures/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const features = data.features || {};
+                    const lines = Object.entries(features).map(([k, v]) => {
+                        const clean = k.replace(/^has/, '').replace(/([A-Z])/g, ' $1').trim();
+                        const formatted = clean.charAt(0).toUpperCase() + clean.slice(1);
+                        return `${formatted}: ${v ? 'sí' : 'no'}`;
+                    });
+                    return { label, status: lines.some(l => /sí$/.test(l)) ? 'ok' : 'info', details: lines };
+                }
+                case 'cookies': {
+                    const data = await fetchWithTimeout(`${API_BASE}/cookies/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const cookies = data.cookies || [];
+                    return { label, status: cookies.length ? 'info' : 'ok', details: cookies.length ? cookies : 'Sin cookies' };
+                }
+                case 'crawlrules': {
+                    const data = await fetchWithTimeout(`${API_BASE}/crawlrules/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    if (!data.found) return { label, status: 'fail', details: 'No encontrado' };
+                    const snippet = escapeHtml((data.content || '').slice(0, 500));
+                    const html = `<pre class="whitespace-pre-wrap text-xs text-gray-700">${snippet}${data.content && data.content.length > 500 ? '…' : ''}</pre>`;
+                    return { label, status: 'ok', details: { html } };
+                }
+                case 'linkedpages': {
+                    const data = await fetchWithTimeout(`${API_BASE}/linkedpages/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const lines = data.links?.slice(0, 20).map(l => `${l.internal ? 'Interno' : 'Externo'}: ${l.href}`) || [];
+                    return { label, status: lines.length ? 'ok' : 'info', details: lines.length ? lines : 'Sin enlaces detectados' };
+                }
+                case 'listedpages': {
+                    const data = await fetchWithTimeout(`${API_BASE}/listedpages/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const pages = data.pages?.slice(0, 20) || [];
+                    return { label, status: pages.length ? 'ok' : 'info', details: pages.length ? pages : 'Sin sitemap' };
+                }
+                case 'socialtags': {
+                    const data = await fetchWithTimeout(`${API_BASE}/socialtags/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const tags = Object.entries(data.tags || {}).map(([k, v]) => `${k}: ${v}`);
+                    return { label, status: tags.length ? 'ok' : 'info', details: tags.length ? tags : 'Sin etiquetas sociales' };
+                }
+                case 'quality': {
+                    const data = await fetchWithTimeout(`${API_BASE}/quality/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const lines = [];
+                    if (typeof data.performance === 'number') lines.push(`Performance: ${(data.performance * 100).toFixed(0)}`);
+                    if (typeof data.accessibility === 'number') lines.push(`Accesibilidad: ${(data.accessibility * 100).toFixed(0)}`);
+                    if (typeof data.bestPractices === 'number') lines.push(`Mejores prácticas: ${(data.bestPractices * 100).toFixed(0)}`);
+                    if (typeof data.seo === 'number') lines.push(`SEO: ${(data.seo * 100).toFixed(0)}`);
+                    return { label, status: lines.length ? 'ok' : 'info', details: lines.length ? lines : 'Sin datos de Lighthouse' };
+                }
+                case 'carbon': {
+                    const data = await fetchWithTimeout(`${API_BASE}/carbon/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const footprint = data.data?.statistics?.co2?.grid?.grams;
+                    return {
+                        label,
+                        status: footprint !== undefined ? 'info' : 'error',
+                        details: footprint !== undefined ? `${footprint.toFixed(2)}g CO₂ por visita` : 'Sin datos'
+                    };
+                }
+                case 'archive': {
+                    const data = await fetchWithTimeout(`${API_BASE}/archive/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const entries = data.entries?.map(e => `${e.timestamp}: ${e.original} (${e.status})`) || [];
+                    return { label, status: entries.length ? 'ok' : 'info', details: entries.length ? entries : 'Sin historial' };
+                }
+                case 'ranking': {
+                    const data = await fetchWithTimeout(`${API_BASE}/ranking/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    return {
+                        label,
+                        status: data.rank ? 'ok' : 'info',
+                        details: data.rank ? `Ranking global ${data.rank}${data.date ? ` (${data.date})` : ''}` : 'Sin ranking'
+                    };
+                }
+                case 'malware': {
+                    const data = await fetchWithTimeout(`${API_BASE}/malware/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const entries = data.entries?.map(e => `${e.url || e.id} (${e.status || 'listado'})`) || [];
+                    const threat = data.threat && data.threat !== 'ok';
+                    return { label, status: threat ? 'fail' : 'ok', details: entries.length ? entries : 'Sin reportes' };
+                }
+                case 'screenshot': {
+                    const data = await fetchWithTimeout(`${API_BASE}/screenshot/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const link = `<a class="text-blue-600 underline" href="${escapeHtml(data.imageUrl)}" target="_blank" rel="noopener">Ver captura</a>`;
+                    return { label, status: 'info', details: { html: link } };
+                }
+                case 'headers': {
+                    const data = await getSecurityHeaders(domain);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const entries = Object.entries(data.headers || {}).map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(', ') : v}`);
+                    return { label, status: entries.length ? 'ok' : 'info', details: entries.length ? entries : 'Sin encabezados' };
+                }
+                case 'sslchain': {
+                    const data = await fetchWithTimeout(`${API_BASE}/sslchain/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const chain = data.chain?.map(c => `${c.subject?.CN || 'Certificado'} → ${c.issuer?.CN || 'Emisor'} (${c.valid_from} - ${c.valid_to})`) || [];
+                    return { label, status: chain.length ? 'ok' : 'fail', details: chain.length ? chain : 'Sin cadena SSL' };
+                }
+                case 'tlsciphers': {
+                    const data = await fetchWithTimeout(`${API_BASE}/tlsciphers/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const suites = data.suites?.map(s => `${s.protocol}: ${s.cipher}`) || [];
+                    return { label, status: suites.length ? 'ok' : 'info', details: suites.length ? suites : 'Sin información' };
+                }
+                case 'tlsconfig': {
+                    const data = await fetchWithTimeout(`${API_BASE}/tlsconfig/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    if (data.data?.error) return { label, status: 'error', details: data.data.error };
+                    const score = data.data?.score;
+                    const details = [];
+                    if (score !== undefined) details.push(`Puntaje: ${score}`);
+                    if (data.data?.tests) {
+                        Object.entries(data.data.tests).slice(0, 10).forEach(([name, result]) => {
+                            if (result && typeof result === 'object' && result.output) {
+                                details.push(`${name}: ${result.output}`);
+                            }
+                        });
+                    }
+                    return { label, status: score !== undefined ? 'ok' : 'info', details: details.length ? details : 'Sin datos' };
+                }
+                case 'tlssimulation': {
+                    const data = await fetchWithTimeout(`${API_BASE}/tlssimulation/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const scenarios = data.scenarios?.map(s => `${s.client}: ${s.success ? `${s.protocol || 'TLS'} (${s.cipher || 'cifra desconocida'})` : 'falló'}`) || [];
+                    const success = data.scenarios?.every(s => s.success);
+                    return { label, status: success ? 'ok' : 'fail', details: scenarios.length ? scenarios : 'Sin datos' };
+                }
+                case 'httpsecurity': {
+                    const data = await fetchWithTimeout(`${API_BASE}/httpsecurity/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    const security = data.security || {};
+                    const lines = Object.entries(security).map(([k, v]) => `${k.toUpperCase()}: ${v ? 'sí' : 'no'}`);
+                    const ok = Object.values(security).some(Boolean);
+                    return { label, status: ok ? 'ok' : 'fail', details: lines.length ? lines : 'Sin cabeceras de seguridad' };
+                }
+                case 'firewall': {
+                    const data = await fetchWithTimeout(`${API_BASE}/firewall/${ascii}`);
+                    if (data.error) return { label, status: 'error', details: data.error };
+                    return {
+                        label,
+                        status: data.detected ? 'ok' : 'info',
+                        details: data.detected ? `Detectado: ${data.waf.join(', ')}` : 'No se identificó WAF'
+                    };
+                }
                 case 'dnssec': {
                     const data = await fetchWithTimeout(`${API_BASE}/dnssec/${ascii}`);
                     const ok = data.valid;
@@ -537,17 +905,17 @@
                     return { label, status: ok ? 'ok' : 'fail', details };
                 }
                 case 'caa': {
-                    const data = await fetchWithTimeout(`${API_BASE}/caa/${domain}`);
+                    const data = await fetchWithTimeout(`${API_BASE}/caa/${ascii}`);
                     if (data.error) return { label, status: 'error', details: data.error };
                     return { label, status: data.records?.length ? 'ok' : 'fail', details: data.records?.length ? data.records.join(', ') : 'No tiene CAA' };
                 }
                 case 'tlsa': {
-                    const data = await fetchWithTimeout(`${API_BASE}/tlsa/${domain}`);
+                    const data = await fetchWithTimeout(`${API_BASE}/tlsa/${ascii}`);
                     if (data.error) return { label, status: 'error', details: data.error };
                     return { label, status: data.records?.length ? 'ok' : 'fail', details: data.records?.length ? data.records.join(', ') : 'No tiene TLSA' };
                 }
                 case 'securitytxt': {
-                    const data = await fetchWithTimeout(`${API_BASE}/securitytxt/${domain}`);
+                    const data = await fetchWithTimeout(`${API_BASE}/securitytxt/${ascii}`);
                     if (data.error) return { label, status: 'error', details: data.error };
                     return { label, status: data.found ? 'ok' : 'fail', details: data.found ? 'Encontrado' : 'No disponible' };
                 }

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
     const aboutText = document.getElementById('aboutText');
     const mapDiv = document.getElementById('map');
     let map; let mapMarkers = [];
-        const API_BASE = 'http://localhost:3000';
+        const API_BASE = 'http://localhost:4000';
     const headerCache = {};
     const tlsCache = {};
 

--- a/server.js
+++ b/server.js
@@ -78,7 +78,7 @@ function smtpQuery(server, port) {
       buffer = lines.pop();
       for (const line of lines) {
         if (!ehloSent && /^220 /.test(line)) {
-          socket.write('EHLO example.com\r\n');
+          socket.write('EHLO www.google.com\r\n');
           ehloSent = true;
         } else if (ehloSent && /^250[ -]/.test(line)) {
           if (/SMTPUTF8/i.test(line)) {
@@ -771,7 +771,7 @@ async function handleOpenPorts(domain, res) {
     ports.map(
       port =>
         new Promise(resolve => {
-          const socket = net.createConnection({ host: domain, port, timeout: 3000 });
+          const socket = net.createConnection({ host: domain, port, timeout: 4000 });
           socket.on('connect', () => {
             results.push({ port, open: true });
             socket.destroy();
@@ -1328,6 +1328,6 @@ const server = http.createServer(async (req, res) => {
   sendJSON(res, 404, { error: 'Not found' });
 });
 
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT || 4000;
 server.listen(PORT, () => console.log(`Server running on port ${PORT}`));
 

--- a/server.js
+++ b/server.js
@@ -1,10 +1,15 @@
 const http = require('http');
 const dns = require('dns').promises;
-dns.setServers(['8.8.8.8', '8.8.4.4']);
+const DEFAULT_SERVERS = ['8.8.8.8', '8.8.4.4'];
+dns.setServers(DEFAULT_SERVERS);
 const net = require('net');
 const https = require('https');
 const tls = require('tls');
 const { domainToASCII } = require('url');
+const { URL } = require('url');
+
+const htmlCache = new Map();
+const headerCache = new Map();
 
 const ALGO_MAP = {
   1: 'RSA/MD5',
@@ -178,10 +183,19 @@ async function handleDkim(domain, selector, res) {
   }
 }
 
-function fetchJSON(target) {
+function pickLib(target) {
+  const url = typeof target === 'string' ? new URL(target) : target;
+  return url.protocol === 'http:' ? http : https;
+}
+
+function fetchJSON(target, options = {}) {
   return new Promise((resolve, reject) => {
-    https
-      .get(target, r => {
+    const url = typeof target === 'string' ? new URL(target) : target;
+    const lib = pickLib(url);
+    const req = lib.request(
+      url,
+      { method: options.method || 'GET', headers: options.headers || {} },
+      r => {
         let data = '';
         r.on('data', chunk => (data += chunk));
         r.on('end', () => {
@@ -191,32 +205,112 @@ function fetchJSON(target) {
             reject(e);
           }
         });
-      })
-      .on('error', reject);
+      }
+    );
+    req.on('error', reject);
+    req.setTimeout(options.timeout || 15000, () => {
+      req.destroy(new Error('Timeout'));
+    });
+    if (options.body) req.write(options.body);
+    req.end();
   });
 }
 
-function fetchText(target) {
+function fetchText(target, options = {}) {
   return new Promise((resolve, reject) => {
-    https
-      .get(target, r => {
+    const url = typeof target === 'string' ? new URL(target) : target;
+    const lib = pickLib(url);
+    const req = lib.request(
+      url,
+      { method: options.method || 'GET', headers: options.headers || {} },
+      r => {
         let data = '';
         r.on('data', chunk => (data += chunk));
         r.on('end', () => resolve(data));
-      })
-      .on('error', reject);
+      }
+    );
+    req.on('error', reject);
+    req.setTimeout(options.timeout || 15000, () => {
+      req.destroy(new Error('Timeout'));
+    });
+    if (options.body) req.write(options.body);
+    req.end();
   });
 }
 
 function fetchHeaders(target, useHttp = false) {
+  return fetchPage(target, { method: 'HEAD', useHttp }).then(({ headers, statusCode }) => ({
+    headers,
+    statusCode
+  }));
+}
+
+function fetchPage(target, options = {}) {
   return new Promise((resolve, reject) => {
-    const lib = useHttp ? http : https;
-    const req = lib.request(target, { method: 'HEAD' }, r => {
-      resolve({ headers: r.headers, statusCode: r.statusCode });
-    });
-    req.on('error', reject);
-    req.end();
+    try {
+      const url = typeof target === 'string' ? new URL(target) : target;
+      const lib = options.useHttp || url.protocol === 'http:' ? http : https;
+      const req = lib.request(
+        url,
+        {
+          method: options.method || 'GET',
+          headers: options.headers || {},
+          timeout: options.timeout || 15000
+        },
+        res => {
+          const chunks = [];
+          res.on('data', chunk => chunks.push(chunk));
+          res.on('end', () => {
+            resolve({
+              statusCode: res.statusCode,
+              headers: res.headers,
+              body: Buffer.concat(chunks).toString(options.encoding || 'utf8')
+            });
+          });
+        }
+      );
+      req.on('error', reject);
+      req.setTimeout(options.timeout || 15000, () => {
+        req.destroy(new Error('Timeout'));
+      });
+      if (options.body) req.write(options.body);
+      req.end();
+    } catch (e) {
+      reject(e);
+    }
   });
+}
+
+function cacheGet(cache, key, ttl = 60000) {
+  const item = cache.get(key);
+  if (!item) return null;
+  if (Date.now() - item.timestamp > ttl) {
+    cache.delete(key);
+    return null;
+  }
+  return item.value;
+}
+
+function cacheSet(cache, key, value) {
+  cache.set(key, { timestamp: Date.now(), value });
+}
+
+async function fetchWebsite(domain) {
+  const cached = cacheGet(htmlCache, domain);
+  if (cached) return cached;
+  const targets = [`https://${domain}`, `http://${domain}`];
+  for (const target of targets) {
+    try {
+      const page = await fetchPage(target);
+      if (page.statusCode && page.statusCode >= 200 && page.statusCode < 400) {
+        const value = { url: target, ...page };
+        cacheSet(htmlCache, domain, value);
+        cacheSet(headerCache, domain, { headers: page.headers, statusCode: page.statusCode });
+        return value;
+      }
+    } catch (e) {}
+  }
+  throw new Error('Servicio no disponible');
 }
 
 async function rpkiValidity(ip) {
@@ -427,6 +521,748 @@ async function handleTls(domain, res) {
   }
 }
 
+async function handleIpInfo(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const [ipv4, ipv6] = await Promise.all([
+      dns.resolve4(domain).catch(() => []),
+      dns.resolve6(domain).catch(() => [])
+    ]);
+    const geo = [];
+    const ips = [...ipv4, ...ipv6].slice(0, 5);
+    for (const ip of ips) {
+      try {
+        const info = await fetchJSON(`https://ipapi.co/${ip}/json/`);
+        geo.push({
+          ip,
+          city: info.city,
+          region: info.region,
+          country: info.country_name,
+          org: info.org || info.org_name,
+          asn: info.asn,
+          latitude: info.latitude,
+          longitude: info.longitude
+        });
+      } catch (e) {}
+    }
+    sendJSON(res, 200, { domain, ipv4, ipv6, geo });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleSslChain(domain, res) {
+  domain = normalizeDomain(domain);
+  let settled = false;
+  try {
+    const socket = tls.connect(
+      { host: domain, servername: domain, port: 443, rejectUnauthorized: false },
+      () => {
+        if (settled) return;
+        settled = true;
+        const chain = [];
+        const seen = new Set();
+        let cert = socket.getPeerCertificate(true);
+        while (cert && Object.keys(cert).length) {
+          if (seen.has(cert.fingerprint256)) break;
+          seen.add(cert.fingerprint256);
+          chain.push({
+            subject: cert.subject,
+            issuer: cert.issuer,
+            valid_from: cert.valid_from,
+            valid_to: cert.valid_to,
+            serialNumber: cert.serialNumber,
+            fingerprint256: cert.fingerprint256,
+            subjectaltname: cert.subjectaltname
+          });
+          if (!cert.issuerCertificate || cert.issuerCertificate === cert) break;
+          cert = cert.issuerCertificate;
+        }
+        const protocol = socket.getProtocol();
+        socket.end();
+        sendJSON(res, 200, { domain, protocol, chain });
+      }
+    );
+    socket.on('error', e => {
+      if (settled) return;
+      settled = true;
+      sendJSON(res, 200, { domain, error: errorMessage(e) });
+    });
+    socket.setTimeout(15000, () => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      sendJSON(res, 200, { domain, error: 'Timeout' });
+    });
+  } catch (e) {
+    if (!settled) sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleDnsRecords(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const records = {};
+    records.A = await dns.resolve4(domain).catch(() => []);
+    records.AAAA = await dns.resolve6(domain).catch(() => []);
+    records.MX = await dns.resolveMx(domain).catch(() => []);
+    records.NS = await dns.resolveNs(domain).catch(() => []);
+    records.TXT = await dns.resolveTxt(domain).catch(() => []);
+    records.CNAME = await dns.resolveCname(domain).catch(() => []);
+    sendJSON(res, 200, { domain, records });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleCookies(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const page = await fetchWebsite(domain);
+    const cookies = page.headers['set-cookie'] || [];
+    sendJSON(res, 200, { domain, cookies });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleCrawlRules(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const urls = [`https://${domain}/robots.txt`, `http://${domain}/robots.txt`];
+    for (const url of urls) {
+      try {
+        const data = await fetchPage(url);
+        if (data.statusCode && data.statusCode < 400) {
+          return sendJSON(res, 200, {
+            domain,
+            found: true,
+            content: data.body
+          });
+        }
+      } catch (e) {}
+    }
+    sendJSON(res, 200, { domain, found: false, content: '' });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleQuality(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const data = await fetchJSON(
+      `https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=https://${domain}`
+    );
+    const lighthouse = data.lighthouseResult?.categories || {};
+    sendJSON(res, 200, {
+      domain,
+      performance: lighthouse.performance?.score,
+      accessibility: lighthouse.accessibility?.score,
+      bestPractices: lighthouse['best-practices']?.score,
+      seo: lighthouse.seo?.score,
+      pwa: lighthouse.pwa?.score || null
+    });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: 'Servicio no disponible' });
+  }
+}
+
+async function handleServerLocation(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const ip = await dns.resolve4(domain).then(r => r[0]).catch(async () => {
+      const v6 = await dns.resolve6(domain);
+      return v6[0];
+    });
+    if (!ip) return sendJSON(res, 200, { domain, error: 'Sin dirección IP' });
+    const info = await fetchJSON(`https://ipapi.co/${ip}/json/`);
+    sendJSON(res, 200, {
+      domain,
+      ip,
+      city: info.city,
+      region: info.region,
+      country: info.country_name,
+      latitude: info.latitude,
+      longitude: info.longitude,
+      timezone: info.timezone
+    });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleAssociatedHosts(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const text = await fetchText(`https://api.hackertarget.com/hostsearch/?q=${domain}`);
+    if (!text || /error/i.test(text))
+      return sendJSON(res, 200, { domain, hosts: [], error: 'Sin datos' });
+    const hosts = text
+      .trim()
+      .split('\n')
+      .map(line => {
+        const [host, ip] = line.split(',');
+        return { host, ip };
+      })
+      .filter(h => h.host);
+    sendJSON(res, 200, { domain, hosts });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function followRedirects(url, limit = 5, chain = []) {
+  if (limit < 0) return chain;
+  const { headers, statusCode } = await fetchPage(url, { method: 'HEAD' });
+  const entry = { url, statusCode, location: headers.location || null };
+  chain.push(entry);
+  if (statusCode && statusCode >= 300 && statusCode < 400 && headers.location) {
+    const next = headers.location.startsWith('http')
+      ? headers.location
+      : new URL(headers.location, url).toString();
+    return followRedirects(next, limit - 1, chain);
+  }
+  return chain;
+}
+
+async function handleRedirectChain(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const chain = await followRedirects(`http://${domain}`);
+    sendJSON(res, 200, { domain, chain });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleTxtRecords(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const records = await dns.resolveTxt(domain);
+    sendJSON(res, 200, { domain, records });
+  } catch (e) {
+    if (e.code === 'ENODATA' || e.code === 'ENOTFOUND')
+      sendJSON(res, 200, { domain, records: [] });
+    else sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleServerStatus(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const page = await fetchPage(`https://${domain}`, { method: 'HEAD' });
+    sendJSON(res, 200, { domain, statusCode: page.statusCode });
+  } catch (e) {
+    try {
+      const page = await fetchPage(`http://${domain}`, { method: 'HEAD', useHttp: true });
+      sendJSON(res, 200, { domain, statusCode: page.statusCode });
+    } catch (err) {
+      sendJSON(res, 200, { domain, error: errorMessage(err) });
+    }
+  }
+}
+
+async function handleOpenPorts(domain, res) {
+  domain = normalizeDomain(domain);
+  const ports = [21, 22, 25, 53, 80, 110, 143, 443, 465, 587, 993, 995, 3306, 8080];
+  const results = [];
+  await Promise.all(
+    ports.map(
+      port =>
+        new Promise(resolve => {
+          const socket = net.createConnection({ host: domain, port, timeout: 3000 });
+          socket.on('connect', () => {
+            results.push({ port, open: true });
+            socket.destroy();
+            resolve();
+          });
+          socket.on('timeout', () => {
+            socket.destroy();
+            resolve();
+          });
+          socket.on('error', () => {
+            resolve();
+          });
+        })
+    )
+  );
+  sendJSON(res, 200, { domain, ports: results });
+}
+
+async function handleTraceroute(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const text = await fetchText(`https://api.hackertarget.com/mtr/?q=${domain}`);
+    const hops = text
+      .split('\n')
+      .slice(1)
+      .filter(Boolean)
+      .map(line => line.trim());
+    sendJSON(res, 200, { domain, hops });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleCarbon(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const data = await fetchJSON(`https://api.websitecarbon.com/site?url=https://${domain}`);
+    sendJSON(res, 200, { domain, data });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: 'Servicio no disponible' });
+  }
+}
+
+async function handleServerInfo(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const ip = await dns.resolve4(domain).then(r => r[0]).catch(async () => {
+      const v6 = await dns.resolve6(domain);
+      return v6[0];
+    });
+    if (!ip) return sendJSON(res, 200, { domain, error: 'Sin dirección IP' });
+    const info = await fetchJSON(`https://ipapi.co/${ip}/json/`);
+    sendJSON(res, 200, {
+      domain,
+      ip,
+      asn: info.asn,
+      org: info.org || info.org_name,
+      network: info.network,
+      isp: info.org || info.isp,
+      country: info.country_name,
+      city: info.city
+    });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleDomainInfo(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const data = await fetchJSON(`https://rdap.org/domain/${domain}`);
+    const events = Array.isArray(data.events) ? data.events : [];
+    const creation = events.find(e => e.eventAction === 'registration')?.eventDate || null;
+    const expiration = events.find(e => e.eventAction === 'expiration')?.eventDate || null;
+    sendJSON(res, 200, {
+      domain,
+      registry: data.registryName || null,
+      status: data.status || [],
+      creation,
+      expiration
+    });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleDnsSecurity(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const google = await dnssecGoogle(domain);
+    let doh = false;
+    try {
+      const cf = await fetchJSON(
+        `https://cloudflare-dns.com/dns-query?name=${domain}&type=DS`,
+        {
+          headers: { accept: 'application/dns-json' }
+        }
+      );
+      doh = Array.isArray(cf.Answer) && cf.Answer.length > 0;
+    } catch (e) {}
+    const algorithms = [...new Set(google.algorithms.filter(Boolean))];
+    sendJSON(res, 200, {
+      domain,
+      methods: { google },
+      doh,
+      valid: google.parent && google.child,
+      algorithms
+    });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+function analyzeSiteFeatures(html) {
+  const lower = html.toLowerCase();
+  return {
+    hasForms: /<form/i.test(lower),
+    hasLogin: /login|iniciar sesi[oó]n|sign in/.test(lower),
+    hasSearch: /type="search"/.test(lower) || /search/.test(lower),
+    hasVideo: /<video|youtube.com\/embed/.test(lower),
+    hasAnalytics: /google-analytics|gtag\(|googletagmanager/.test(lower),
+    hasEcommerce: /cart|checkout|woocommerce/.test(lower)
+  };
+}
+
+function detectTechStack(html) {
+  const lower = html.toLowerCase();
+  const stack = [];
+  if (/wp-content|wordpress/.test(lower)) stack.push('WordPress');
+  if (/drupal/.test(lower)) stack.push('Drupal');
+  if (/joomla/.test(lower)) stack.push('Joomla');
+  if (/shopify/.test(lower)) stack.push('Shopify');
+  if (/react/.test(lower)) stack.push('React');
+  if (/vue/.test(lower)) stack.push('Vue.js');
+  if (/angular/.test(lower)) stack.push('Angular');
+  if (/bootstrap/.test(lower)) stack.push('Bootstrap');
+  if (/jquery/.test(lower)) stack.push('jQuery');
+  return [...new Set(stack)];
+}
+
+function extractLinks(html, domain) {
+  const links = [];
+  const regex = /<a\s+[^>]*href=["']([^"'#]+)["'][^>]*>/gi;
+  let match;
+  while ((match = regex.exec(html))) {
+    const href = match[1];
+    const internal = href.startsWith('/') || href.includes(domain);
+    links.push({ href, internal });
+  }
+  return links;
+}
+
+function extractSocialTags(html) {
+  const tags = {};
+  const metaRegex = /<meta\s+([^>]+)>/gi;
+  let match;
+  while ((match = metaRegex.exec(html))) {
+    const attrs = match[1];
+    const propertyMatch = attrs.match(/property=["']([^"']+)["']/i);
+    const nameMatch = attrs.match(/name=["']([^"']+)["']/i);
+    const contentMatch = attrs.match(/content=["']([^"']*)["']/i);
+    const key = propertyMatch?.[1] || nameMatch?.[1];
+    if (key && contentMatch) tags[key] = contentMatch[1];
+  }
+  return tags;
+}
+
+async function handleSiteFeatures(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const page = await fetchWebsite(domain);
+    const features = analyzeSiteFeatures(page.body);
+    sendJSON(res, 200, { domain, features });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleDnsServer(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const servers = await dns.resolveNs(domain);
+    sendJSON(res, 200, { domain, servers });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleTechStack(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const page = await fetchWebsite(domain);
+    const stack = detectTechStack(page.body);
+    sendJSON(res, 200, { domain, stack });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleListedPages(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const urls = [`https://${domain}/sitemap.xml`, `http://${domain}/sitemap.xml`];
+    for (const url of urls) {
+      try {
+        const data = await fetchPage(url);
+        if (data.statusCode && data.statusCode < 400) {
+          const matches = [...data.body.matchAll(/<loc>([^<]+)<\/loc>/gi)].map(m => m[1]);
+          return sendJSON(res, 200, { domain, pages: matches });
+        }
+      } catch (e) {}
+    }
+    sendJSON(res, 200, { domain, pages: [] });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleLinkedPages(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const page = await fetchWebsite(domain);
+    const links = extractLinks(page.body, domain);
+    sendJSON(res, 200, { domain, links });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleSocialTags(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const page = await fetchWebsite(domain);
+    const tags = extractSocialTags(page.body);
+    sendJSON(res, 200, { domain, tags });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleEmailConfig(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const [txt, mx] = await Promise.all([
+      dns.resolveTxt(domain).catch(() => []),
+      dns.resolveMx(domain).catch(() => [])
+    ]);
+    const flat = txt.map(row => row.join('')).join(' ');
+    const spf = /v=spf1/i.test(flat);
+    const dmarc = /v=DMARC1/i.test(flat);
+    let dkim = false;
+    try {
+      const def = await dns.resolveTxt(`default._domainkey.${domain}`);
+      dkim = def.flat().some(v => /v=DKIM1/i.test(v));
+    } catch (e) {}
+    sendJSON(res, 200, {
+      domain,
+      spf,
+      dmarc,
+      dkim,
+      mx: mx.map(r => ({ exchange: r.exchange, priority: r.priority }))
+    });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleFirewall(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const page = await fetchWebsite(domain);
+    const headers = page.headers;
+    const server = (headers['server'] || '').toLowerCase();
+    const wafHeaders = Object.values(headers)
+      .join(' ')
+      .toLowerCase();
+    const detections = [];
+    if (server.includes('cloudflare') || wafHeaders.includes('cloudflare')) detections.push('Cloudflare');
+    if (server.includes('sucuri') || wafHeaders.includes('sucuri')) detections.push('Sucuri');
+    if (server.includes('akamai') || wafHeaders.includes('akamai')) detections.push('Akamai');
+    if (wafHeaders.includes('mod_security') || wafHeaders.includes('modsecurity')) detections.push('ModSecurity');
+    sendJSON(res, 200, {
+      domain,
+      waf: detections,
+      detected: detections.length > 0
+    });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleHttpSecurity(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const cached = cacheGet(headerCache, domain);
+    const headers = cached ? cached.headers : (await fetchWebsite(domain)).headers;
+    const security = {
+      hsts: Boolean(headers['strict-transport-security']),
+      csp: Boolean(headers['content-security-policy']),
+      xfo: Boolean(headers['x-frame-options']),
+      xcto: Boolean(headers['x-content-type-options']),
+      xxss: Boolean(headers['x-xss-protection']),
+      referrer: Boolean(headers['referrer-policy'])
+    };
+    sendJSON(res, 200, { domain, security });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleArchive(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const data = await fetchJSON(
+      `https://web.archive.org/cdx/search/cdx?url=${domain}&output=json&limit=5&fl=timestamp,original,statuscode`
+    );
+    const entries = Array.isArray(data)
+      ? data.slice(1).map(item => ({ timestamp: item[0], original: item[1], status: item[2] }))
+      : [];
+    sendJSON(res, 200, { domain, entries });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: 'Servicio no disponible' });
+  }
+}
+
+async function handleRanking(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const data = await fetchJSON(`https://tranco-list.eu/api/ranks/domain/${domain}`);
+    sendJSON(res, 200, { domain, rank: data.rank || null, date: data.list_date || null });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: 'Sin información' });
+  }
+}
+
+async function handleBlock(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const resolvers = [
+      {
+        name: 'Google',
+        url: `https://dns.google/resolve?name=${domain}&type=A`
+      },
+      {
+        name: 'Cloudflare',
+        url: `https://cloudflare-dns.com/dns-query?name=${domain}&type=A`,
+        headers: { accept: 'application/dns-json' }
+      },
+      {
+        name: 'Quad9',
+        url: `https://dns.quad9.net/dns-query?name=${domain}&type=A`,
+        headers: { accept: 'application/dns-json' }
+      }
+    ];
+    const results = [];
+    for (const resolver of resolvers) {
+      try {
+        const data = await fetchJSON(resolver.url, { headers: resolver.headers });
+        const answers = Array.isArray(data.Answer)
+          ? data.Answer.filter(a => a.type === 1)
+          : [];
+        results.push({ resolver: resolver.name, blocked: answers.length === 0 });
+      } catch (e) {
+        results.push({ resolver: resolver.name, blocked: true });
+      }
+    }
+    sendJSON(res, 200, { domain, results });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleMalware(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const body = `host=${encodeURIComponent(domain)}`;
+    const data = await fetchJSON('https://urlhaus-api.abuse.ch/v1/host/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body
+    });
+    const entries = Array.isArray(data?.urls) ? data.urls.slice(0, 10) : [];
+    sendJSON(res, 200, { domain, entries, threat: data?.query_status });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: 'Servicio no disponible' });
+  }
+}
+
+async function handleTlsCiphers(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const suites = [];
+    const protocols = ['TLSv1.3', 'TLSv1.2'];
+    for (const version of protocols) {
+      await new Promise(resolve => {
+        const socket = tls.connect(
+          {
+            host: domain,
+            servername: domain,
+            port: 443,
+            rejectUnauthorized: false,
+            minVersion: version,
+            maxVersion: version
+          },
+          () => {
+            const cipher = socket.getCipher();
+            if (cipher) suites.push({ protocol: socket.getProtocol(), cipher: cipher.name });
+            socket.end();
+            resolve();
+          }
+        );
+        socket.on('error', () => resolve());
+        socket.setTimeout(7000, () => {
+          socket.destroy();
+          resolve();
+        });
+      });
+    }
+    sendJSON(res, 200, { domain, suites });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleTlsConfig(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const data = await fetchJSON(
+      `https://tls-observatory.services.mozilla.com/api/v1/analyze?host=${domain}`
+    );
+    sendJSON(res, 200, { domain, data });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: 'Servicio no disponible' });
+  }
+}
+
+async function handleTlsSimulation(domain, res) {
+  domain = normalizeDomain(domain);
+  try {
+    const scenarios = [];
+    const clients = [
+      { name: 'Modern Browser', minVersion: 'TLSv1.3', maxVersion: 'TLSv1.3' },
+      { name: 'Legacy Browser', minVersion: 'TLSv1.2', maxVersion: 'TLSv1.2' }
+    ];
+    for (const client of clients) {
+      await new Promise(resolve => {
+        const socket = tls.connect(
+          {
+            host: domain,
+            servername: domain,
+            port: 443,
+            rejectUnauthorized: false,
+            minVersion: client.minVersion,
+            maxVersion: client.maxVersion
+          },
+          () => {
+            const cipher = socket.getCipher();
+            scenarios.push({
+              client: client.name,
+              protocol: socket.getProtocol(),
+              cipher: cipher ? cipher.name : null,
+              success: true
+            });
+            socket.end();
+            resolve();
+          }
+        );
+        socket.on('error', () => {
+          scenarios.push({ client: client.name, success: false });
+          resolve();
+        });
+        socket.setTimeout(7000, () => {
+          socket.destroy();
+          scenarios.push({ client: client.name, success: false });
+          resolve();
+        });
+      });
+    }
+    sendJSON(res, 200, { domain, scenarios });
+  } catch (e) {
+    sendJSON(res, 200, { domain, error: errorMessage(e) });
+  }
+}
+
+async function handleScreenshot(domain, res) {
+  domain = normalizeDomain(domain);
+  const encoded = encodeURIComponent(`https://${domain}`);
+  const imageUrl = `https://image.thum.io/get/png/${encoded}`;
+  sendJSON(res, 200, { domain, imageUrl });
+}
+
 const server = http.createServer(async (req, res) => {
   const parsed = new URL(req.url, 'http://localhost');
   const segments = parsed.pathname.split('/').filter(Boolean);
@@ -443,6 +1279,52 @@ const server = http.createServer(async (req, res) => {
   if (segments[0] === 'securitytxt' && segments[1])
     return handleSecurityTxt(segments[1], res);
   if (segments[0] === 'tlsinfo' && segments[1]) return handleTls(segments[1], res);
+  if (segments[0] === 'ipinfo' && segments[1]) return handleIpInfo(segments[1], res);
+  if (segments[0] === 'sslchain' && segments[1]) return handleSslChain(segments[1], res);
+  if (segments[0] === 'dnsrecords' && segments[1]) return handleDnsRecords(segments[1], res);
+  if (segments[0] === 'cookies' && segments[1]) return handleCookies(segments[1], res);
+  if (segments[0] === 'crawlrules' && segments[1]) return handleCrawlRules(segments[1], res);
+  if (segments[0] === 'quality' && segments[1]) return handleQuality(segments[1], res);
+  if (segments[0] === 'serverlocation' && segments[1])
+    return handleServerLocation(segments[1], res);
+  if (segments[0] === 'associatedhosts' && segments[1])
+    return handleAssociatedHosts(segments[1], res);
+  if (segments[0] === 'redirectchain' && segments[1])
+    return handleRedirectChain(segments[1], res);
+  if (segments[0] === 'txtrecords' && segments[1]) return handleTxtRecords(segments[1], res);
+  if (segments[0] === 'serverstatus' && segments[1])
+    return handleServerStatus(segments[1], res);
+  if (segments[0] === 'openports' && segments[1]) return handleOpenPorts(segments[1], res);
+  if (segments[0] === 'traceroute' && segments[1]) return handleTraceroute(segments[1], res);
+  if (segments[0] === 'carbon' && segments[1]) return handleCarbon(segments[1], res);
+  if (segments[0] === 'serverinfo' && segments[1]) return handleServerInfo(segments[1], res);
+  if (segments[0] === 'domaininfo' && segments[1]) return handleDomainInfo(segments[1], res);
+  if (segments[0] === 'dnssecurity' && segments[1])
+    return handleDnsSecurity(segments[1], res);
+  if (segments[0] === 'sitefeatures' && segments[1])
+    return handleSiteFeatures(segments[1], res);
+  if (segments[0] === 'dnsserver' && segments[1]) return handleDnsServer(segments[1], res);
+  if (segments[0] === 'techstack' && segments[1]) return handleTechStack(segments[1], res);
+  if (segments[0] === 'listedpages' && segments[1]) return handleListedPages(segments[1], res);
+  if (segments[0] === 'linkedpages' && segments[1]) return handleLinkedPages(segments[1], res);
+  if (segments[0] === 'socialtags' && segments[1]) return handleSocialTags(segments[1], res);
+  if (segments[0] === 'emailconfig' && segments[1])
+    return handleEmailConfig(segments[1], res);
+  if (segments[0] === 'firewall' && segments[1]) return handleFirewall(segments[1], res);
+  if (segments[0] === 'httpsecurity' && segments[1])
+    return handleHttpSecurity(segments[1], res);
+  if (segments[0] === 'archive' && segments[1]) return handleArchive(segments[1], res);
+  if (segments[0] === 'ranking' && segments[1]) return handleRanking(segments[1], res);
+  if (segments[0] === 'block' && segments[1]) return handleBlock(segments[1], res);
+  if (segments[0] === 'malware' && segments[1]) return handleMalware(segments[1], res);
+  if (segments[0] === 'tlsciphers' && segments[1])
+    return handleTlsCiphers(segments[1], res);
+  if (segments[0] === 'tlsconfig' && segments[1])
+    return handleTlsConfig(segments[1], res);
+  if (segments[0] === 'tlssimulation' && segments[1])
+    return handleTlsSimulation(segments[1], res);
+  if (segments[0] === 'screenshot' && segments[1])
+    return handleScreenshot(segments[1], res);
   sendJSON(res, 404, { error: 'Not found' });
 });
 


### PR DESCRIPTION
## Summary
- expand the API to expose OSINT-style probes including IP intelligence, DNS/TLS insights, content analysis, reputation lookups, and supporting helpers/caching
- reorganize the single-page UI so checks are rendered dynamically in grouped accordions and implement result rendering for the new probes
- enhance the client-side logic with HTML escaping, reusable formatting helpers, and handlers for each new backend check

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cdca3d82f08329b10e922101c41305